### PR TITLE
Add configurable elevation angle limits

### DIFF
--- a/src/camera-manager.ts
+++ b/src/camera-manager.ts
@@ -70,9 +70,12 @@ class CameraManager {
         const isObjectExperience = !bbox.containsPoint(resetCamera.position);
         const animTrack = getAnimTrack(resetCamera, isObjectExperience);
 
+        const pitchMin = settings.elevationRange?.min ?? -90;
+        const pitchMax = settings.elevationRange?.max ?? 90;
+
         const controllers = {
-            orbit: new OrbitController(),
-            fly: new FlyController(),
+            orbit: new OrbitController(pitchMin, pitchMax),
+            fly: new FlyController(pitchMin, pitchMax),
             walk: new WalkController(),
             anim: animTrack ? new AnimController(animTrack) : null
         };
@@ -81,6 +84,8 @@ class CameraManager {
         controllers.fly.fov = resetCamera.fov;
         controllers.fly.collider = collider;
         controllers.walk.collider = collider;
+        controllers.walk.pitchMin = pitchMin;
+        controllers.walk.pitchMax = pitchMax;
 
         const walkSource = new WalkSource();
         walkSource.onComplete = () => {

--- a/src/cameras/fly-controller.ts
+++ b/src/cameras/fly-controller.ts
@@ -23,9 +23,9 @@ class FlyController implements CameraController {
     /** Optional voxel collider for sphere collision with sliding */
     collider: VoxelCollider | null = null;
 
-    constructor() {
+    constructor(pitchMin = -90, pitchMax = 90) {
         this.controller = new FlyControllerPC();
-        this.controller.pitchRange = new Vec2(-90, 90);
+        this.controller.pitchRange = new Vec2(pitchMin, pitchMax);
         this.controller.rotateDamping = 0.97;
         this.controller.moveDamping = 0.97;
     }

--- a/src/cameras/orbit-controller.ts
+++ b/src/cameras/orbit-controller.ts
@@ -13,10 +13,10 @@ class OrbitController implements CameraController {
 
     fov = 90;
 
-    constructor() {
+    constructor(pitchMin = -90, pitchMax = 90) {
         this.controller = new OrbitControllerPC();
         this.controller.zoomRange = new Vec2(0.01, Infinity);
-        this.controller.pitchRange = new Vec2(-90, 90);
+        this.controller.pitchRange = new Vec2(pitchMin, pitchMax);
         this.controller.rotateDamping = 0.97;
         this.controller.moveDamping = 0.97;
         this.controller.zoomDamping = 0.97;

--- a/src/cameras/walk-controller.ts
+++ b/src/cameras/walk-controller.ts
@@ -35,6 +35,16 @@ class WalkController implements CameraController {
     collider: VoxelCollider | null = null;
 
     /**
+     * Minimum pitch angle in degrees (looking down limit).
+     */
+    pitchMin = -90;
+
+    /**
+     * Maximum pitch angle in degrees (looking up limit).
+     */
+    pitchMax = 90;
+
+    /**
      * Field of view in degrees for walk mode.
      */
     fov = 96;
@@ -152,7 +162,7 @@ class WalkController implements CameraController {
 
         // apply rotation at display rate for responsive mouse look
         this._angles.add(v.set(-rotate[1], -rotate[0], 0));
-        this._angles.x = math.clamp(this._angles.x, -90, 90);
+        this._angles.x = math.clamp(this._angles.x, this.pitchMin, this.pitchMax);
 
         // accumulate movement input so frames without a physics step don't lose input
         this._pendingMove[0] += move[0];

--- a/src/schemas/v2.ts
+++ b/src/schemas/v2.ts
@@ -78,7 +78,12 @@ type ExperienceSettings = {
     cameras: Camera[],
     annotations: Annotation[],
 
-    startMode: 'default' | 'animTrack' | 'annotation'
+    startMode: 'default' | 'animTrack' | 'annotation',
+
+    elevationRange?: {
+        min: number,
+        max: number
+    }
 };
 
 export type { AnimTrack, Camera, Annotation, PostEffectSettings, ExperienceSettings };


### PR DESCRIPTION
## Summary

- Add optional `elevationRange` (`min`/`max` in degrees) to the v2 experience settings schema
- `OrbitController`, `FlyController`, and `WalkController` now use configurable pitch limits instead of hardcoded `-90`/`90`
- Defaults remain unchanged (`-90` to `90`) when the setting is omitted, ensuring full backward compatibility

## Changes

| File | Change |
|------|--------|
| `src/schemas/v2.ts` | Add optional `elevationRange` to `ExperienceSettings` |
| `src/cameras/orbit-controller.ts` | Accept `pitchMin`/`pitchMax` constructor params |
| `src/cameras/fly-controller.ts` | Accept `pitchMin`/`pitchMax` constructor params |
| `src/cameras/walk-controller.ts` | Add `pitchMin`/`pitchMax` properties, use in clamp |
| `src/camera-manager.ts` | Read `elevationRange` from settings, pass to all controllers |

## Usage

Add to experience settings JSON:

```json
{
  "elevationRange": {
    "min": -45,
    "max": 60
  }
}
```

## Test plan

- [x] Verify default behavior (no `elevationRange` set) — pitch should still clamp to -90°/90°
- [ ] Set custom `elevationRange` (e.g. `min: -30, max: 45`) and verify orbit camera respects limits
- [ ] Verify fly camera respects the same limits
- [ ] Verify walk camera respects the same limits
- [ ] Verify camera transitions between modes preserve elevation constraints

https://claude.ai/code/session_01FHAKC2H3E1HyJn7fAjViJn