### PR TITLE
Add gaussian transition effect on scene load

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,7 @@ const loadGsplat = async (app: AppBase, config: Config, progressCallback: (progr
             const material = entity.gsplat.unified ? app.scene.gsplat.material : entity.gsplat.material;
             material.setDefine('GSPLAT_AA', aa);
             material.setParameter('alphaClip', 1 / 255);
+            material.setParameter('splatTransition', 0);
             app.root.addChild(entity);
             resolve(entity);
         });

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -27,13 +27,39 @@ import {
 import { Annotations } from './annotations';
 import { CameraManager } from './camera-manager';
 import { Camera } from './cameras/camera';
-import { nearlyEquals } from './core/math';
+import { easeOut, nearlyEquals } from './core/math';
 import { InputController } from './input-controller';
 import type { ExperienceSettings, PostEffectSettings } from './settings';
 import type { Global } from './types';
 import type { VoxelCollider } from './voxel-collider';
 import { VoxelDebugOverlay } from './voxel-debug-overlay';
 import { WalkCursor } from './walk-cursor';
+
+// Shader chunk overrides for the gaussian transition effect.
+// splatTransition uniform controls the scale (0 = point cloud, 1 = full gaussian).
+const gsplatModifyGlsl = `
+uniform float splatTransition;
+void modifySplatCenter(inout vec3 center) {
+}
+void modifySplatRotationScale(vec3 originalCenter, vec3 modifiedCenter, inout vec4 rotation, inout vec3 scale) {
+    scale *= mix(0.01, 1.0, splatTransition);
+}
+void modifySplatColor(vec3 center, inout vec4 color) {
+    color.a *= smoothstep(0.0, 0.3, splatTransition);
+}
+`;
+
+const gsplatModifyWgsl = `
+uniform splatTransition: f32;
+fn modifySplatCenter(center: ptr<function, vec3f>) {
+}
+fn modifySplatRotationScale(originalCenter: vec3f, modifiedCenter: vec3f, rotation: ptr<function, vec4f>, scale: ptr<function, vec3f>) {
+    *scale *= mix(0.01, 1.0, uniform.splatTransition);
+}
+fn modifySplatColor(center: vec3f, color: ptr<function, vec4f>) {
+    (*color).a *= smoothstep(0.0, 0.3, uniform.splatTransition);
+}
+`;
 
 const gammaChunkGlsl = `
 vec3 prepareOutputFromGamma(vec3 gammaColor) {
@@ -134,13 +160,21 @@ class Viewer {
     origChunks: {
         glsl: {
             gsplatOutputVS: string,
+            gsplatModifyVS: string,
             skyboxPS: string
         },
         wgsl: {
             gsplatOutputVS: string,
+            gsplatModifyVS: string,
             skyboxPS: string
         }
     };
+
+    transitionTime = -1;
+
+    transitionDuration = 1.5;
+
+    gsplatEntity: Entity | null = null;
 
     constructor(global: Global, gsplatLoad: Promise<Entity>, skyboxLoad: Promise<void> | undefined, voxelLoad: Promise<VoxelCollider> | undefined) {
         this.global = global;
@@ -161,13 +195,19 @@ class Viewer {
         this.origChunks = {
             glsl: {
                 gsplatOutputVS: glsl.get('gsplatOutputVS'),
+                gsplatModifyVS: glsl.get('gsplatModifyVS'),
                 skyboxPS: glsl.get('skyboxPS')
             },
             wgsl: {
                 gsplatOutputVS: wgsl.get('gsplatOutputVS'),
+                gsplatModifyVS: wgsl.get('gsplatModifyVS'),
                 skyboxPS: wgsl.get('skyboxPS')
             }
         };
+
+        // override gsplatModifyVS with transition-aware version
+        glsl.set('gsplatModifyVS', gsplatModifyGlsl);
+        wgsl.set('gsplatModifyVS', gsplatModifyWgsl);
 
         // disable auto render, we'll render only when camera changes
         app.autoRender = false;
@@ -277,6 +317,16 @@ class Viewer {
                 applyCamera(this.cameraManager.camera);
             }
 
+            // animate the gaussian transition effect
+            if (this.transitionTime >= 0 && this.transitionTime < this.transitionDuration) {
+                this.transitionTime = Math.min(this.transitionTime + deltaTime, this.transitionDuration);
+                const t = easeOut(this.transitionTime / this.transitionDuration);
+                const material = this.gsplatEntity?.gsplat?.unified
+                    ? app.scene.gsplat.material
+                    : this.gsplatEntity?.gsplat?.material;
+                material?.setParameter('splatTransition', t);
+                app.renderNextFrame = true;
+            }
         });
 
         // Render voxel debug overlay
@@ -284,14 +334,16 @@ class Viewer {
             this.voxelOverlay?.update();
         });
 
-        // update state on first frame
+        // update state on first frame and start the gaussian transition
         events.on('firstFrame', () => {
             state.loaded = true;
             state.animationPaused = !!config.noanim;
+            this.transitionTime = 0;
         });
 
         // wait for the model to load
         Promise.all([gsplatLoad, skyboxLoad, voxelLoad]).then((results) => {
+            this.gsplatEntity = results[0];
             const gsplat = results[0].gsplat as GSplatComponent;
             const collider = results[2];
 


### PR DESCRIPTION
## Summary

- Adds a visual transition effect where gaussian splats animate from a point cloud state to the final full gaussian rendering when the scene first loads
- Overrides the `gsplatModifyVS` shader chunk to control splat scale and opacity via a `splatTransition` uniform
- Animates the transition over 1.5 seconds with easeOut easing, starting after the first frame renders

## How it works

1. **Scale transition**: Splat scale interpolates from 1% (`0.01`) to 100% (`1.0`) — at the start, splats appear as tiny points, then grow to their full gaussian size
2. **Opacity fade-in**: Splat alpha fades in quickly during the first 30% of the transition using `smoothstep(0.0, 0.3, t)`, so splats become fully opaque early while still growing
3. **Easing**: Uses the existing `easeOut` function for a natural deceleration curve
4. **Dual shader support**: Both GLSL and WGSL versions are provided for WebGL and WebGPU compatibility

## Test plan

- [ ] Load a `.ply` gaussian splat scene and verify the transition animates from point cloud to full gaussian
- [ ] Load a unified/LOD (`.lod-meta.json`) scene and verify the transition works
- [ ] Test with WebGPU enabled (`?webgpu`) to verify WGSL shader path
- [ ] Verify no visual artifacts after transition completes (splats should look identical to before this change)

https://claude.ai/code/session_01K7c7ris2FjUXjDXwR7JXKV